### PR TITLE
Remove all get_session() calls from method signatures, reuse sessions wherever possible.

### DIFF
--- a/applications/completist_oneday.py
+++ b/applications/completist_oneday.py
@@ -6,20 +6,23 @@ Track all oneday participation for last year.
 from datetime import datetime
 from operator import itemgetter
 
+from llama_slobber import get_session
 from llama_slobber import collect_onedays
 from llama_slobber import ll_oneday_players
 
 
-def action():
+def action(session=None):
     """
     Track all oneday participation for last year.
     """
+    if session is None:
+        session = get_session()
     compyear = datetime.today().year - 1
-    onedays = collect_onedays(compyear)
+    onedays = collect_onedays(compyear, session=session)
     precs = {}
     qcount = 0
     for quiz in onedays:
-        plist = ll_oneday_players(quiz)
+        plist = ll_oneday_players(quiz, session=session)
         if plist:
             qcount += 1
         for llama in plist:

--- a/applications/save_personal_data.py
+++ b/applications/save_personal_data.py
@@ -8,13 +8,14 @@ import sys
 import codecs
 from json import dumps
 from json import loads
+from llama_slobber import get_session
 from llama_slobber import get_season
 from llama_slobber import act_on_all_rundles
 from llama_slobber import get_rundle_personal
 from llama_slobber import out_csv_file
 
 
-def personal_by_rundle(season, rundle, payload):
+def personal_by_rundle(season, rundle, payload, session=None):
     """
     Create json file of personal information for this rundle.
 
@@ -24,15 +25,18 @@ def personal_by_rundle(season, rundle, payload):
         payload -- dictionary where 'output_directory' entry contains the
                    name of the directory where data will be stored
     """
+    if session is None:
+        session = get_session()
     print(rundle, flush=True)
-    outstr = dumps(get_rundle_personal(season, rundle), indent=4)
+    outstr = dumps(get_rundle_personal(season, rundle, session=session),
+                   indent=4)
     outdir = payload['output_directory']
     fname = "%s%s%s.json" % (outdir, os.sep, rundle)
     with open(fname, "w") as ofile:
         ofile.write(outstr)
 
 
-def personal_dict(season, rundle, payload):
+def personal_dict(season, rundle, payload, session=None):
     """
     Add to large payload dictionary.
 
@@ -41,12 +45,14 @@ def personal_dict(season, rundle, payload):
         rundle -- rundle name
         payload -- dictionary where results will be stored
     """
+    if session is None:
+        session = get_session()
     print(rundle, flush=True)
-    data = get_rundle_personal(season, rundle)
+    data = get_rundle_personal(season, rundle, session=session)
     payload.update(data)
 
 
-def save_personal_data(json_dir, out_dir):
+def save_personal_data(json_dir, out_dir, session=None):
     """
     Save personal data
 
@@ -56,16 +62,19 @@ def save_personal_data(json_dir, out_dir):
     First store all the personal data into json files named by the rundle.
     Then store all the personal data into one big json file.
     """
+    if session is None:
+        session = get_session()
     sys.stdout = codecs.getwriter("utf-8")(sys.stdout.detach())
-    season = get_season()
+    season = get_season(session=session)
     files_that_exist = os.listdir(json_dir)
     if len(files_that_exist) < 5:
         act_on_all_rundles(season, personal_by_rundle,
-                           {'output_directory': json_dir})
+                           {'output_directory': json_dir},
+                           session=session)
     everybody = '%s%severybody.json' % (out_dir, os.sep)
     if 'everybody.json' not in files_that_exist:
         payload = {}
-        act_on_all_rundles(season, personal_dict, payload)
+        act_on_all_rundles(season, personal_dict, payload, session=session)
         outstr = dumps(payload, indent=4)
         with open(everybody, "w") as ofile:
             ofile.write(outstr)

--- a/applications/save_user_hist.py
+++ b/applications/save_user_hist.py
@@ -5,6 +5,7 @@ Save match history for all players
 """
 from json import dump
 from json import loads
+from llama_slobber import get_session
 from llama_slobber import SPLITTER_IN_DICTNAMES
 
 
@@ -24,7 +25,7 @@ def dowrite(name1, name2, idata, outdir):
         dump(idata, fout)
 
 
-def save_user_hist(user_func, outdir):
+def save_user_hist(user_func, outdir, session=None):
     """
     Read generated_files/people.json to get players.
 
@@ -33,6 +34,8 @@ def save_user_hist(user_func, outdir):
     Store that data in match_data files.  Each file contains 100 entries
     and are named and sorted in alphabetical order
     """
+    if session is None:
+        session = get_session()
     with open('generated_files/people.json', 'r') as infile:
         intext = infile.read()
     indata = loads(intext)
@@ -43,7 +46,7 @@ def save_user_hist(user_func, outdir):
         if count % 100 == 0:
             out_data = {}
             fname = player
-        out_data[player] = user_func(player)
+        out_data[player] = user_func(player, session=session)
         if count == 0:
             continue
         if count % 100 == 99:

--- a/llama_slobber/act_on_all_rundles.py
+++ b/llama_slobber/act_on_all_rundles.py
@@ -6,12 +6,13 @@ Find all players in a given season
 """
 import sys
 import codecs
+from llama_slobber import get_session
 from llama_slobber import get_season
 from llama_slobber import get_leagues
 from llama_slobber import get_rundles
 
 
-def act_on_all_rundles(season, action, payload):
+def act_on_all_rundles(season, action, payload, session=None):
     """
     Act on all rundles
 
@@ -25,14 +26,16 @@ def act_on_all_rundles(season, action, payload):
         2. Perform operations on the rundle, payload will be other input
            parameters
     """
-    leagues = get_leagues(season)
+    if session is None:
+        session = get_session()
+    leagues = get_leagues(season, session=session)
     for league in leagues:
-        for rundle in get_rundles(season, league):
-            action(season, rundle, payload)
+        for rundle in get_rundles(season, league, session=session):
+            action(season, rundle, payload, session=session)
     return payload
 
 
-def append_action(_, rundle, payload):
+def append_action(_, rundle, payload, session=None):
     """
     Simplest action case -- append rundle name to list
 

--- a/llama_slobber/calc_hun.py
+++ b/llama_slobber/calc_hun.py
@@ -27,10 +27,10 @@ def calc_hun(player1, player2, session_id=None):
     Returns -- a HUN number in the range of 0 to 1.  A higher value indicates
                that the players are more 'like' each other.
     """
-    if not session_id:
+    if session_id is None:
         session_id = get_session()
-    plyr1 = get_qhist(player1, session_id)
-    plyr2 = get_qhist(player2, session_id)
+    plyr1 = get_qhist(player1, session=session_id)
+    plyr2 = get_qhist(player2, session=session_id)
     return comp_hun(plyr1, plyr2)
 
 

--- a/llama_slobber/calc_wonder.py
+++ b/llama_slobber/calc_wonder.py
@@ -93,19 +93,20 @@ def calc_wonder(season, rundle, session_id=None):
                entire season
     """
     wonderv = [0, -1, -2, 1, 0, -1, 2, 1, 0]
-    if not session_id:
+    if session_id is None:
         session_id = get_session()
-    current_season = get_season(session_id)
+    current_season = get_season(session=session_id)
     if season == current_season:
-        match_count = get_matchcount(session_id)
+        match_count = get_matchcount(session=session_id)
     else:
         match_count = TOTAL_MATCHES_PER_SEASON
-    pdata = get_rundle_personal(season, rundle)
+    pdata = get_rundle_personal(season, rundle, session=session_id)
     players = {}
     for plyr in pdata:
         players[plyr] = 0
     for day in range(0, match_count):
-        for match_res in get_matchresult(season, day+1, rundle):
+        for match_res in get_matchresult(season, day+1, rundle,
+                                         session=session_id):
             results = match_anal(match_res)
             players[results[0]] += wonderv[results[2]]
             players[results[1]] -= wonderv[results[2]]

--- a/llama_slobber/find_wlt_patterns.py
+++ b/llama_slobber/find_wlt_patterns.py
@@ -4,6 +4,7 @@
 """
 Find patterns in the game records for a player
 """
+from llama_slobber.ll_local_io import get_session
 from llama_slobber.ll_user_record import get_user_data
 
 
@@ -37,11 +38,13 @@ def find_wlt_patterns(pinfo):
     return result
 
 
-def get_wlt_patterns(player):
+def get_wlt_patterns(player, session=None):
     """
     Call get_user_data to get w-l-t record prior to calling find_wlt_patterns.
     """
-    pinfo = get_user_data(player.lower())[1]
+    if session is None:
+        session = get_session()
+    pinfo = get_user_data(player.lower(), session=session)[1]
     return find_wlt_patterns(pinfo)
 
 

--- a/llama_slobber/ll_collect_onedays.py
+++ b/llama_slobber/ll_collect_onedays.py
@@ -63,10 +63,12 @@ class GetOneDayQuiz(HTMLParser):
 
 
 @handle_conn_err
-def collect_onedays(year=-1, session=get_session()):
+def collect_onedays(year=-1, session=None):
     """
     Year is a keyword argument.  Default is collect all.
     """
+    if session is None:
+        session = get_session()
     return get_page_data(ONEDAYS, GetOneDayQuiz(year), session=session)
 
 

--- a/llama_slobber/ll_get_rundle_comp.py
+++ b/llama_slobber/ll_get_rundle_comp.py
@@ -11,7 +11,7 @@ from llama_slobber.calc_hun import calc_hun
 from llama_slobber.fmt_float import format_float
 
 
-def get_rundle_comp(season, rundle, fsize, session_id=get_session(),
+def get_rundle_comp(season, rundle, fsize, session_id=None,
                     func_parm=calc_hun):
     """
     Perform a calculation between all members of a rundle.
@@ -29,6 +29,8 @@ def get_rundle_comp(season, rundle, fsize, session_id=get_session(),
         based on func_parm.  These tuples are arranged in decending value
         of this func_parm number.
     """
+    if session_id is None:
+        session_id = get_session()
     folks = get_rundle_members(season, rundle, session=session_id)
     result = {}
     for plyr in folks:

--- a/llama_slobber/ll_leagues.py
+++ b/llama_slobber/ll_leagues.py
@@ -44,10 +44,12 @@ class GetLeagueNames(HTMLParser):
 
 
 @handle_conn_err
-def get_leagues(season, session=get_session()):
+def get_leagues(season, session=None):
     """
     Get a list of leagues for the season specified.
     """
+    if session is None:
+        session = get_session()
     main_data = LLSTANDINGS + "%d" % season
     return get_page_data(main_data, GetLeagueNames(season), session=session)
 

--- a/llama_slobber/ll_local_io.py
+++ b/llama_slobber/ll_local_io.py
@@ -49,7 +49,7 @@ def get_session():
     return ses1
 
 
-def get_page_data(url, parser, session=get_session()):
+def get_page_data(url, parser, session=None):
     """
     Extract data from a url
 
@@ -61,6 +61,8 @@ def get_page_data(url, parser, session=get_session()):
     Returns:
         data collected by parser
     """
+    if session is None:
+        session = get_session()
     main_data = session.get(url)
     parser1 = parser
     parser1.feed(main_data.text)

--- a/llama_slobber/ll_matchcount.py
+++ b/llama_slobber/ll_matchcount.py
@@ -42,7 +42,7 @@ class GetCurrentlyFinishedCount(HTMLParser):
 
 
 @handle_conn_err
-def get_matchcount(session=get_session()):
+def get_matchcount(session=None):
     """
     Find matches in current season
 
@@ -50,7 +50,9 @@ def get_matchcount(session=get_session()):
         session request
 
     """
-    return get_page_data(ARUNDLE % (get_season(), 'Pacific'),
+    if session is None:
+        session = get_session()
+    return get_page_data(ARUNDLE % (get_season(session=session), 'Pacific'),
                          GetCurrentlyFinishedCount(), session=session)
 
 

--- a/llama_slobber/ll_matchday.py
+++ b/llama_slobber/ll_matchday.py
@@ -56,7 +56,9 @@ class MatchDay(object):
     PSIZE = INFO_PER_USER - 1
     QTOTAL = 6
 
-    def __init__(self, season, match_day, rundle, session=get_session()):
+    def __init__(self, season, match_day, rundle, session=None):
+        if session is None:
+            session = get_session()
         self.info = {}
         self.info['season'] = season
         self.info['day'] = match_day
@@ -69,7 +71,7 @@ class MatchDay(object):
             self.info['division'] = int(parts[-1])
         page = '&'.join([str(season), str(match_day), rundle])
         self.url = MATCH_DATA % page
-        self.raw_data = get_page_data(self.url, GetMatchDay(), session)
+        self.raw_data = get_page_data(self.url, GetMatchDay(), session=session)
         if len(self.raw_data) % MatchDay.INFO_PER_USER != 0:
             raise ValueError('LL Parsing Error')
         self.num_folks = len(self.raw_data) // MatchDay.INFO_PER_USER
@@ -109,7 +111,7 @@ class MatchDay(object):
 
 
 @handle_conn_err
-def get_matchday(season, day, rundle, session=get_session()):
+def get_matchday(season, day, rundle, session=None):
     """
     Extract match day information
 
@@ -129,6 +131,8 @@ def get_matchday(season, day, rundle, session=get_session()):
         The second entry is a dictionary of values related to the entire
         match day object (league, rundle, division, day, season).
     """
+    if session is None:
+        session = get_session()
     matchday = MatchDay(season, day, rundle, session=session)
     return [matchday.get_results(), matchday.get_info()]
 

--- a/llama_slobber/ll_matchresult.py
+++ b/llama_slobber/ll_matchresult.py
@@ -57,7 +57,7 @@ class GetMatchResult(HTMLParser):
 
 
 @handle_conn_err
-def get_matchresult(season, day, rundle, session=get_session()):
+def get_matchresult(season, day, rundle, session=None):
     """
     Extract match day results
 
@@ -72,6 +72,8 @@ def get_matchresult(season, day, rundle, session=get_session()):
             players -- list of players (2 in a match)
             score -- list of corresponding match scores (strings)
     """
+    if session is None:
+        session = get_session()
     page = '&'.join([str(season), str(day), rundle])
     this_url = MATCH_DATA % page
     return get_page_data(this_url, GetMatchResult(), session=session)

--- a/llama_slobber/ll_oneday_players.py
+++ b/llama_slobber/ll_oneday_players.py
@@ -24,10 +24,12 @@ FILE_PATTERNS = ['/%s.shtml', '/%s.php', '.php?%s', '/results.php?%s&1']
 
 
 @handle_conn_err
-def ll_oneday_players(oneday, session=get_session()):
+def ll_oneday_players(oneday, session=None):
     """
     Extract a list of players from the oneday passed in
     """
+    if session is None:
+        session = get_session()
     dval = parse_oneday_get_date(oneday, session=session)
     indx = 0
     for boundary in DATE_BOUNDARIES:

--- a/llama_slobber/ll_onedays.py
+++ b/llama_slobber/ll_onedays.py
@@ -56,10 +56,12 @@ class GetOnedayInfo(HTMLParser):
 
 
 @handle_conn_err
-def get_onedays(session=get_session()):
+def get_onedays(session=None):
     """
     Get oneday records from ONEDAYS page
     """
+    if session is None:
+        session = get_session()
     return get_page_data(ONEDAYS, GetOnedayInfo(), session=session)
 
 

--- a/llama_slobber/ll_parse_oneday_get_date.py
+++ b/llama_slobber/ll_parse_oneday_get_date.py
@@ -44,12 +44,14 @@ class GetDateFromUrl(HTMLParser):
 
 
 @handle_conn_err
-def parse_oneday_get_date(oneday, session=get_session()):
+def parse_oneday_get_date(oneday, session=None):
     """
     Find the date of a oneday event.
 
     Returns a date value
     """
+    if session is None:
+        session = get_session()
     urlv = "%s.php?%s" % (ONEDAYS, oneday)
     one_day_str = get_page_data(urlv, GetDateFromUrl(), session=session)
     extract = one_day_str.strip()

--- a/llama_slobber/ll_personal_data.py
+++ b/llama_slobber/ll_personal_data.py
@@ -57,7 +57,7 @@ class GetPersonalInfo(HTMLParser):
 
 
 @handle_conn_err
-def get_personal_data(person, session=get_session()):
+def get_personal_data(person, session=None):
     """
     Get information on a person
 
@@ -67,6 +67,8 @@ def get_personal_data(person, session=get_session()):
 
     Returns: dictionary of user's metadata (Location, Gender, College)
     """
+    if session is None:
+        session = get_session()
     page = "%s/profiles.php?%s" % (LLHEADER, person.lower())
     return get_page_data(page, GetPersonalInfo(), session=session)
 

--- a/llama_slobber/ll_qhist.py
+++ b/llama_slobber/ll_qhist.py
@@ -59,13 +59,15 @@ class GetQhist(HTMLParser):
 
 
 @handle_conn_err
-def get_qhist(player, session=get_session()):
+def get_qhist(player, session=None):
     """
     Extract player's question history.
 
     Returns a dict indexed by categories.  Each dict entry consists
     of a 'correct' list and a 'wrong' list of questions asked.
     """
+    if session is None:
+        session = get_session()
     pname = player.lower()
     main_data = QHIST % pname
     return get_page_data(main_data, GetQhist(pname), session=session)

--- a/llama_slobber/ll_read_csv_file.py
+++ b/llama_slobber/ll_read_csv_file.py
@@ -8,10 +8,12 @@ from llama_slobber.ll_local_io import get_session
 from llama_slobber.ll_local_io import LLHEADER
 
 
-def get_csv_oneday_players(quiz, session=get_session()):
+def get_csv_oneday_players(quiz, session=None):
     """
     Return a list of Llamas who participated in the indicated one-day quiz.
     """
+    if session is None:
+        session = get_session()
     results = get_csv_oneday_data(quiz, session=session)
     retval = []
     for data in results:
@@ -19,19 +21,23 @@ def get_csv_oneday_players(quiz, session=get_session()):
     return retval
 
 
-def get_csv_oneday_data(quiz, session=get_session()):
+def get_csv_oneday_data(quiz, session=None):
     """
     Given a quiz name, return the csv file for that quiz.
     """
+    if session is None:
+        session = get_session()
     httpv = "%s/oneday/csv/%s.csv" % (LLHEADER, quiz)
     return read_csv_data(httpv, session=session)
 
 
-def read_csv_data(url, session=get_session()):
+def read_csv_data(url, session=None):
     """
     Read a csv file pointed to by a url.  Return a list of lines.  Each
     line is a list of fields.
     """
+    if session is None:
+        session = get_session()
     main_data = session.get(url)
     flines = main_data.text.strip().split('\n')
     retval = []

--- a/llama_slobber/ll_rundle_members.py
+++ b/llama_slobber/ll_rundle_members.py
@@ -47,7 +47,7 @@ class GetRundleMembers(HTMLParser):
 
 
 @handle_conn_err
-def get_rundle_members(season, rundle, session=get_session()):
+def get_rundle_members(season, rundle, session=None):
     """
     Get players in a rundle
 
@@ -58,11 +58,13 @@ def get_rundle_members(season, rundle, session=get_session()):
 
     Returns list of user names of players in the rundle
     """
+    if session is None:
+        session = get_session()
     page = "%s%d&%s" % (LLSTANDINGS, season, rundle)
     return get_page_data(page, GetRundleMembers(), session=session)
 
 
-def get_rundle_personal(season, rundle, session=get_session()):
+def get_rundle_personal(season, rundle, session=None):
     """
     Call get_personal_data on all members of a rundle.
 
@@ -73,10 +75,12 @@ def get_rundle_personal(season, rundle, session=get_session()):
 
     Return personal info in a dictionary indexed by person.
     """
+    if session is None:
+        session = get_session()
     retv = {}
     plist = get_rundle_members(season, rundle, session=session)
     for person in plist:
-        retv[person] = get_personal_data(person, session)
+        retv[person] = get_personal_data(person, session=session)
     return retv
 
 

--- a/llama_slobber/ll_rundles.py
+++ b/llama_slobber/ll_rundles.py
@@ -38,10 +38,12 @@ class GetRundles(HTMLParser):
 
 
 @handle_conn_err
-def get_rundles(season, league, session=get_session()):
+def get_rundles(season, league, session=None):
     """
     Get a list of rundles for the season and league specified.
     """
+    if session is None:
+        session = get_session()
     main_data = LLSTANDINGS + "%d&%s" % (season, league)
     return get_page_data(main_data, GetRundles(season, league),
                          session=session)

--- a/llama_slobber/ll_season.py
+++ b/llama_slobber/ll_season.py
@@ -34,7 +34,7 @@ class GetSeasonNumber(HTMLParser):
 
 
 @handle_conn_err
-def get_season(session=get_session()):
+def get_season(session=None):
     """
     Find the season number
 
@@ -43,6 +43,8 @@ def get_season(session=get_session()):
 
     Returns most recent season number
     """
+    if session is None:
+        session = get_session()
     return int(get_page_data(LLHEADER, GetSeasonNumber(), session=session))
 
 

--- a/llama_slobber/ll_user_record.py
+++ b/llama_slobber/ll_user_record.py
@@ -50,7 +50,7 @@ class GetUserData(HTMLParser):
 
 
 @handle_conn_err
-def get_user_data(player, session=get_session()):
+def get_user_data(player, session=None):
     """
     Return information about a user:
         Tuple of two dicts:
@@ -62,6 +62,8 @@ def get_user_data(player, session=get_session()):
         player -- player name
         session request
     """
+    if session is None:
+        session = get_session()
     return get_page_data(USER_DATA % player.lower(), GetUserData(),
                          session=session)
 


### PR DESCRIPTION
As fellow Python scraping tool scrapy [says](https://blog.scrapinghub.com/2016/08/25/how-to-crawl-the-web-politely-with-scrapy):
> The first rule of web crawling is you do not harm the website. The second rule of web crawling is you do **NOT** harm the website.

On that note, I noticed that when I added logging to see the requests being made by this library, there were a startling number of login attempts made, just for doing an `import llama_slobber`! It seems that Python attempts to initialize all the default parameters at import time, meaning that anywhere there's a `session=get_session()` in a function signature, it's getting called, and LearnedLeague is getting spammed.

With these changes, sessions are only created when absolutely necessary, and they are reused wherever it was possible to do so.